### PR TITLE
Sequence orquestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ It is responsible for executing the different steps of each pipeline. The core d
 #### Synchronous
 The same process can have 1 or more pipeline defined, when it is executed it will do so sequentially, executing the same step for each pipeline. That is, first it will execute the Input of all the pipelines, then the transform together with the mapper of each pipeline and finally the output of each pipeline.
 
+#### Sequence
+This orchestrator allows us to better define the sequence of a pipeline. We can execute a `Transformer` with the data returned by another transformer or even indicate several of them.
+If a transformer depends on more than 1 `Transformer` or `Input` step, then in the "transform" method we will receive a tuple with each set of data.
+It also allows us to execute all Inputs in parallel to optimize the pipeline execution speed.
+
+The way to define the pipeline for this orchestrator is as follows:
+
+```python
+from cybertron_framework.orchestrator.types.sequence import SequenceOrchestrator
+
+pipeline_steps = [
+    {"id": "input1", "type": "input", "manager": InputBigqueryManager()},
+    {"id": "input2", "type": "input", "manager": InputPostgresManager()},
+    {"id": "transformer1", "type": "transformer", "manager": TransformerBigqueryManager(), "inputs": ["input1"]},
+    {"id": "transformer2", "type": "transformer", "manager": TransformerPostgresManager(), "inputs": ["input2"]},
+    {"id": "transformer3", "type": "transformer", "manager": FinalTransformerManager(), "inputs": ["transformer1", "transformer2"]},
+    {"id": "output1", "type": "output", "manager": FirstOutputManager(), "inputs": ["transformer3"]},
+]
+
+orchestrator = SequenceOrchestrator()
+orchestrator.run(pipeline_steps)
+```
+
 ---
 
 

--- a/cybertron_framework/environment/__tests__/test_environment.py
+++ b/cybertron_framework/environment/__tests__/test_environment.py
@@ -1,4 +1,5 @@
 import unittest
+
 # from cybertron_framework.test_setup import *  # noqa: F401, F403
 from unittest.mock import Mock, mock_open, patch
 

--- a/cybertron_framework/environment/environment.py
+++ b/cybertron_framework/environment/environment.py
@@ -1,6 +1,7 @@
 import os
 
 import yaml
+
 from cybertron_framework.environment.environment_interface import IEnvironment
 
 DEFAULT_VARIABLE_VALUE = None

--- a/cybertron_framework/helper/__tests__/test_logger.py
+++ b/cybertron_framework/helper/__tests__/test_logger.py
@@ -14,7 +14,7 @@ class TestLogger(unittest.TestCase):
     @patch("cybertron_framework.helper.logger.logging")
     def test_info_logs_correctly(self, logging_mock):
         self.logger.info("Test message")
-        
+
         logging_mock.info.assert_called_with("Test message")
 
     @patch("cybertron_framework.helper.logger.logging")
@@ -23,31 +23,26 @@ class TestLogger(unittest.TestCase):
         mock_format_exc.return_value = "Traceback Error test"
         expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        
         self.logger.warning("Test message", from_exception=True)
-            
+
         logging_mock.warning.assert_called_with(expected_result)
-        
+
     @patch("cybertron_framework.helper.logger.logging")
     @patch("traceback.format_exc")
     def test_error_logs_correctly(self, mock_format_exc, logging_mock):
         mock_format_exc.return_value = "Traceback Error test"
         expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        
         self.logger.error("Test message", from_exception=True)
-            
+
         logging_mock.error.assert_called_with(expected_result)
 
-        
     @patch("cybertron_framework.helper.logger.logging")
     @patch("traceback.format_exc")
     def test_critical_logs_correctly(self, mock_format_exc, logging_mock):
         mock_format_exc.return_value = "Traceback Error test"
         expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        
         self.logger.critical("Test message", from_exception=True)
-            
-        logging_mock.critical.assert_called_with(expected_result)
 
+        logging_mock.critical.assert_called_with(expected_result)

--- a/cybertron_framework/helper/__tests__/test_logger.py
+++ b/cybertron_framework/helper/__tests__/test_logger.py
@@ -1,8 +1,9 @@
 import unittest
 from unittest.mock import patch
 
-from cybertron_framework.helper.logger import Logger
 from freezegun import freeze_time
+
+from cybertron_framework.helper.logger import Logger
 
 
 class TestLogger(unittest.TestCase):

--- a/cybertron_framework/helper/__tests__/test_logger.py
+++ b/cybertron_framework/helper/__tests__/test_logger.py
@@ -11,40 +11,43 @@ class TestLogger(unittest.TestCase):
         self.logger = Logger()
 
     @freeze_time("2022-1-1")
-    def test_info_logs_correctly(self):
-        expected_result = "[01/01/2022 00:00:00] INFO | Test message"
+    @patch("cybertron_framework.helper.logger.logging")
+    def test_info_logs_correctly(self, logging_mock):
+        self.logger.info("Test message")
+        
+        logging_mock.info.assert_called_with("Test message")
 
-        self.assertEqual(self.logger.info("Test message"), expected_result)
-
-    @freeze_time("2022-1-1 12:00:00")
+    @patch("cybertron_framework.helper.logger.logging")
     @patch("traceback.format_exc")
-    def test_warning_logs_correctly(self, mock_format_exc):
+    def test_warning_logs_correctly(self, mock_format_exc, logging_mock):
         mock_format_exc.return_value = "Traceback Error test"
-        expected_result = "[01/01/2022 12:00:00] WARNING | Test message | Traceback Error test"  # noqa: E501
+        expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        self.assertEqual(
-            self.logger.warning("Test message", from_exception=True),
-            expected_result,
-        )
-
-    @freeze_time("2022-1-1 12:00:00")
+        
+        self.logger.warning("Test message", from_exception=True)
+            
+        logging_mock.warning.assert_called_with(expected_result)
+        
+    @patch("cybertron_framework.helper.logger.logging")
     @patch("traceback.format_exc")
-    def test_error_logs_correctly(self, mock_format_exc):
+    def test_error_logs_correctly(self, mock_format_exc, logging_mock):
         mock_format_exc.return_value = "Traceback Error test"
-        expected_result = "[01/01/2022 12:00:00] ERROR | Test message | Traceback Error test"  # noqa: E501
+        expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        self.assertEqual(
-            self.logger.error("Test message", from_exception=True),
-            expected_result,
-        )
+        
+        self.logger.error("Test message", from_exception=True)
+            
+        logging_mock.error.assert_called_with(expected_result)
 
-    @freeze_time("2022-1-1 12:00:00")
+        
+    @patch("cybertron_framework.helper.logger.logging")
     @patch("traceback.format_exc")
-    def test_critical_logs_correctly(self, mock_format_exc):
+    def test_critical_logs_correctly(self, mock_format_exc, logging_mock):
         mock_format_exc.return_value = "Traceback Error test"
-        expected_result = "[01/01/2022 12:00:00] CRITICAL | Test message | Traceback Error test"  # noqa: E501
+        expected_result = "Test message | Traceback Error test"  # noqa: E501
 
-        self.assertEqual(
-            self.logger.critical("Test message", from_exception=True),
-            expected_result,
-        )
+        
+        self.logger.critical("Test message", from_exception=True)
+            
+        logging_mock.critical.assert_called_with(expected_result)
+

--- a/cybertron_framework/helper/logger.py
+++ b/cybertron_framework/helper/logger.py
@@ -12,16 +12,6 @@ class Logger:
     Logs messages to the stdout
     """
 
-    LOG_TYPE_WARNING = "WARNING"
-    LOG_TYPE_ERROR = "ERROR"
-    LOG_TYPE_CRITICAL = "CRITICAL"
-
-    LOGGER_MAP = {
-        LOG_TYPE_WARNING: logging.warning,
-        LOG_TYPE_ERROR: logging.error,
-        LOG_TYPE_CRITICAL: logging.critical,
-    }
-
     def info(self, message):
         return logging.info(message)
 

--- a/cybertron_framework/helper/logger.py
+++ b/cybertron_framework/helper/logger.py
@@ -1,6 +1,5 @@
-import traceback
 import logging
-
+import traceback
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,13 +26,19 @@ class Logger:
         return logging.info(message)
 
     def warning(self, message, from_exception=False):
-        return logging.warning(self.__build_error_message(message, from_exception))
+        return logging.warning(
+            self.__build_error_message(message, from_exception)
+        )
 
     def error(self, message, from_exception=False):
-        return logging.error(self.__build_error_message(message, from_exception))
+        return logging.error(
+            self.__build_error_message(message, from_exception)
+        )
 
     def critical(self, message, from_exception=False):
-        return logging.critical(self.__build_error_message(message, from_exception))
+        return logging.critical(
+            self.__build_error_message(message, from_exception)
+        )
 
     def __build_error_message(self, message, from_exception=False):
         if from_exception:

--- a/cybertron_framework/helper/logger.py
+++ b/cybertron_framework/helper/logger.py
@@ -1,5 +1,11 @@
 import traceback
-from datetime import datetime
+import logging
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 
 
 class Logger:
@@ -7,28 +13,30 @@ class Logger:
     Logs messages to the stdout
     """
 
-    LOG_TYPE_INFO = "INFO"
     LOG_TYPE_WARNING = "WARNING"
     LOG_TYPE_ERROR = "ERROR"
     LOG_TYPE_CRITICAL = "CRITICAL"
 
+    LOGGER_MAP = {
+        LOG_TYPE_WARNING: logging.warning,
+        LOG_TYPE_ERROR: logging.error,
+        LOG_TYPE_CRITICAL: logging.critical,
+    }
+
     def info(self, message):
-        return self.__log(self.LOG_TYPE_INFO, message)
+        return logging.info(message)
 
     def warning(self, message, from_exception=False):
-        return self.__log(self.LOG_TYPE_WARNING, message, from_exception)
+        return logging.warning(self.__build_error_message(message, from_exception))
 
     def error(self, message, from_exception=False):
-        return self.__log(self.LOG_TYPE_ERROR, message, from_exception)
+        return logging.error(self.__build_error_message(message, from_exception))
 
     def critical(self, message, from_exception=False):
-        return self.__log(self.LOG_TYPE_CRITICAL, message, from_exception)
+        return logging.critical(self.__build_error_message(message, from_exception))
 
-    def __log(self, type, message, from_exception=False):
-        now = datetime.now()
-        timestamp = now.strftime("%d/%m/%Y %H:%M:%S")
-        result = f"[{timestamp}] {type} | {message}"
+    def __build_error_message(self, message, from_exception=False):
         if from_exception:
-            result = result + f" | {traceback.format_exc()}"
+            message = f"{message} | {traceback.format_exc()}"
 
-        return result
+        return message

--- a/cybertron_framework/orchestrator/abstract_orchestrator.py
+++ b/cybertron_framework/orchestrator/abstract_orchestrator.py
@@ -1,7 +1,9 @@
 from cybertron_framework.helper.benchmark import Benchmark
 from cybertron_framework.helper.logger import Logger
 from cybertron_framework.input.input_manager_interface import IInputManager
-from cybertron_framework.orchestrator.orchestrator_interface import IOrchestrator  # noqa: E501
+from cybertron_framework.orchestrator.orchestrator_interface import (  # noqa: E501
+    IOrchestrator,
+)
 from cybertron_framework.output.output_manager_interface import IOutputManager
 from cybertron_framework.transformer.transformer_manager_interface import (
     ITransformerManager,

--- a/cybertron_framework/orchestrator/types/__tests__/test_sequence.py
+++ b/cybertron_framework/orchestrator/types/__tests__/test_sequence.py
@@ -1,0 +1,133 @@
+import unittest
+from unittest.mock import MagicMock
+
+from cybertron_framework.input.input_manager_interface import IInputManager
+from cybertron_framework.orchestrator.types.sequence import (
+    SequenceOrchestrator,
+)
+from cybertron_framework.output.output_manager_interface import IOutputManager
+from cybertron_framework.transformer.transformer_manager_interface import (
+    ITransformerManager,
+)
+
+
+def mock_first_input_success():
+    mock_input_manager = MagicMock(spec=IInputManager)
+
+    input_data = [{"pipeline_unique_id": "input_data"}]
+    mock_input_manager.get_data.return_value = input_data
+
+    return mock_input_manager
+
+def mock_second_input_success():
+    mock_input_manager = MagicMock(spec=IInputManager)
+
+    input_data = [{"pipeline_unique_id2": "input_data2"}]
+    mock_input_manager.get_data.return_value = input_data
+
+    return mock_input_manager
+
+
+def mock_first_transform_success():
+    mock_transformer_manager = MagicMock(spec=ITransformerManager)
+    transformed_data = [{"pipeline_unique_id": "transformed_data"}]
+    mock_transformer_manager.transform.return_value = transformed_data
+
+    return mock_transformer_manager
+
+def mock_second_transform_success():
+    mock_transformer_manager = MagicMock(spec=ITransformerManager)
+    transformed_data = [{"pipeline_unique_id2": "transformed_data2"}]
+    mock_transformer_manager.transform.return_value = transformed_data
+
+    return mock_transformer_manager
+
+def mock_thrid_transform_success():
+    mock_transformer_manager = MagicMock(spec=ITransformerManager)
+    transformed_data = [{"pipeline_unique_id": "transformed_data"}, {"pipeline_unique_id2": "transformed_data2"},]
+    mock_transformer_manager.transform.return_value = transformed_data
+
+    return mock_transformer_manager
+
+
+def mock_first_output_success():
+    mock_output_manager = MagicMock(spec=IOutputManager)
+
+    return mock_output_manager
+
+
+class TestDynamicOrchestrator(unittest.TestCase):
+    def setUp(self):
+        self.orchestrator = SequenceOrchestrator()
+        self.mock_input_manager = mock_first_input_success()
+        self.mock_transformer_manager = mock_first_transform_success()
+        self.mock_output_manager = mock_first_output_success()
+
+        self.pipeline_steps = [
+            {
+                "id": "input1",
+                "type": "input",
+                "manager": self.mock_input_manager,
+            },
+            {
+                "id": "transformer1",
+                "type": "transformer",
+                "manager": self.mock_transformer_manager,
+                "inputs": ["input1"],
+            },
+            {
+                "id": "output1",
+                "type": "output",
+                "manager": self.mock_output_manager,
+                "inputs": ["transformer1"],
+            },
+        ]
+
+    def test_sequence_orquestrator_run_each_step_with_correct_oarams(self):
+        orchestrator = SequenceOrchestrator()
+
+        orchestrator.run(self.pipeline_steps)
+
+        self.mock_input_manager.get_data.assert_called_with()
+        self.mock_transformer_manager.transform.assert_called_with(
+            [{"pipeline_unique_id": "input_data"}]
+        )
+        self.mock_output_manager.put.assert_called_with(
+            [{"pipeline_unique_id": "transformed_data"}]
+        )
+
+    def test_sequence_orquestrator_run_each_step_with_multiple_steps_dependencies(
+        self,
+    ):
+        second_input_mock = mock_second_input_success()
+        second_transformer_mock = mock_second_transform_success()
+        third_transformer_mock = mock_thrid_transform_success()
+        orchestrator = SequenceOrchestrator()
+
+        pipeline_steps = [
+            {"id": "input1", "type": "input", "manager": self.mock_input_manager},
+            {"id": "input2", "type": "input", "manager": second_input_mock},
+            {"id": "transformer1", "type": "transformer", "manager": self.mock_transformer_manager, "inputs": ["input1"]},
+            {"id": "transformer2", "type": "transformer", "manager": second_transformer_mock, "inputs": ["input2"]},
+            {"id": "transformer3", "type": "transformer", "manager": third_transformer_mock, "inputs": ["transformer1", "transformer2"]},
+            {"id": "output1", "type": "output", "manager": self.mock_output_manager, "inputs": ["transformer3"]},
+        ]
+        
+        orchestrator.run(pipeline_steps)
+        
+        self.mock_input_manager.get_data.assert_called_with()
+        second_input_mock.get_data.assert_called_with()
+        
+        self.mock_transformer_manager.transform.assert_called_with(
+            [{"pipeline_unique_id": "input_data"}]
+        )
+        second_transformer_mock.transform.assert_called_with(
+            [{'pipeline_unique_id2': 'input_data2'}]
+        )
+        third_transformer_mock.transform.assert_called_with(
+            [{'pipeline_unique_id': 'transformed_data'}], [{'pipeline_unique_id2': 'transformed_data2'}],
+        )
+        
+        self.mock_output_manager.put.assert_called_with(
+            [{'pipeline_unique_id': 'transformed_data'}, {'pipeline_unique_id2': 'transformed_data2'}]
+        )

--- a/cybertron_framework/orchestrator/types/__tests__/test_sequence.py
+++ b/cybertron_framework/orchestrator/types/__tests__/test_sequence.py
@@ -19,6 +19,7 @@ def mock_first_input_success():
 
     return mock_input_manager
 
+
 def mock_second_input_success():
     mock_input_manager = MagicMock(spec=IInputManager)
 
@@ -35,6 +36,7 @@ def mock_first_transform_success():
 
     return mock_transformer_manager
 
+
 def mock_second_transform_success():
     mock_transformer_manager = MagicMock(spec=ITransformerManager)
     transformed_data = [{"pipeline_unique_id2": "transformed_data2"}]
@@ -42,9 +44,13 @@ def mock_second_transform_success():
 
     return mock_transformer_manager
 
+
 def mock_thrid_transform_success():
     mock_transformer_manager = MagicMock(spec=ITransformerManager)
-    transformed_data = [{"pipeline_unique_id": "transformed_data"}, {"pipeline_unique_id2": "transformed_data2"},]
+    transformed_data = [
+        {"pipeline_unique_id": "transformed_data"},
+        {"pipeline_unique_id2": "transformed_data2"},
+    ]
     mock_transformer_manager.transform.return_value = transformed_data
 
     return mock_transformer_manager
@@ -96,7 +102,7 @@ class TestDynamicOrchestrator(unittest.TestCase):
             [{"pipeline_unique_id": "transformed_data"}]
         )
 
-    def test_sequence_orquestrator_run_each_step_with_multiple_steps_dependencies(
+    def test_sequence_orquestrator_run_each_step_with_multiple_steps_dependencies(  # noqa: E501
         self,
     ):
         second_input_mock = mock_second_input_success()
@@ -105,29 +111,57 @@ class TestDynamicOrchestrator(unittest.TestCase):
         orchestrator = SequenceOrchestrator()
 
         pipeline_steps = [
-            {"id": "input1", "type": "input", "manager": self.mock_input_manager},
+            {
+                "id": "input1",
+                "type": "input",
+                "manager": self.mock_input_manager,
+            },
             {"id": "input2", "type": "input", "manager": second_input_mock},
-            {"id": "transformer1", "type": "transformer", "manager": self.mock_transformer_manager, "inputs": ["input1"]},
-            {"id": "transformer2", "type": "transformer", "manager": second_transformer_mock, "inputs": ["input2"]},
-            {"id": "transformer3", "type": "transformer", "manager": third_transformer_mock, "inputs": ["transformer1", "transformer2"]},
-            {"id": "output1", "type": "output", "manager": self.mock_output_manager, "inputs": ["transformer3"]},
+            {
+                "id": "transformer1",
+                "type": "transformer",
+                "manager": self.mock_transformer_manager,
+                "inputs": ["input1"],
+            },
+            {
+                "id": "transformer2",
+                "type": "transformer",
+                "manager": second_transformer_mock,
+                "inputs": ["input2"],
+            },
+            {
+                "id": "transformer3",
+                "type": "transformer",
+                "manager": third_transformer_mock,
+                "inputs": ["transformer1", "transformer2"],
+            },
+            {
+                "id": "output1",
+                "type": "output",
+                "manager": self.mock_output_manager,
+                "inputs": ["transformer3"],
+            },
         ]
-        
+
         orchestrator.run(pipeline_steps)
-        
+
         self.mock_input_manager.get_data.assert_called_with()
         second_input_mock.get_data.assert_called_with()
-        
+
         self.mock_transformer_manager.transform.assert_called_with(
             [{"pipeline_unique_id": "input_data"}]
         )
         second_transformer_mock.transform.assert_called_with(
-            [{'pipeline_unique_id2': 'input_data2'}]
+            [{"pipeline_unique_id2": "input_data2"}]
         )
         third_transformer_mock.transform.assert_called_with(
-            [{'pipeline_unique_id': 'transformed_data'}], [{'pipeline_unique_id2': 'transformed_data2'}],
+            [{"pipeline_unique_id": "transformed_data"}],
+            [{"pipeline_unique_id2": "transformed_data2"}],
         )
-        
+
         self.mock_output_manager.put.assert_called_with(
-            [{'pipeline_unique_id': 'transformed_data'}, {'pipeline_unique_id2': 'transformed_data2'}]
+            [
+                {"pipeline_unique_id": "transformed_data"},
+                {"pipeline_unique_id2": "transformed_data2"},
+            ]
         )

--- a/cybertron_framework/orchestrator/types/sequence.py
+++ b/cybertron_framework/orchestrator/types/sequence.py
@@ -1,5 +1,8 @@
 import concurrent.futures
-from cybertron_framework.orchestrator.abstract_orchestrator import AbstractOrchestrator
+
+from cybertron_framework.orchestrator.abstract_orchestrator import (
+    AbstractOrchestrator,
+)
 
 
 class SequenceOrchestrator(AbstractOrchestrator):
@@ -7,8 +10,10 @@ class SequenceOrchestrator(AbstractOrchestrator):
         self.benchmark.start("total")
 
         input_data = self._process_parallel_inputs(pipeline_steps)
-        
-        transformer_outputs = self._process_transformers(pipeline_steps, input_data)
+
+        transformer_outputs = self._process_transformers(
+            pipeline_steps, input_data
+        )
 
         self._process_output(pipeline_steps, transformer_outputs)
 
@@ -34,7 +39,7 @@ class SequenceOrchestrator(AbstractOrchestrator):
         self.logger.info("Finished parallel input process.")
 
         return input_data
-    
+
     def _process_transformers(self, pipeline_steps, input_data):
         self.logger.info("Starting transformers process.")
         self.benchmark.start("transform")
@@ -47,10 +52,18 @@ class SequenceOrchestrator(AbstractOrchestrator):
                 transformer_manager = step["manager"]
                 input_ids = step.get("inputs", [])
 
-                inputs = [input_data[input_id] for input_id in input_ids if input_id in input_data]
+                inputs = [
+                    input_data[input_id]
+                    for input_id in input_ids
+                    if input_id in input_data
+                ]
 
                 if not inputs:
-                    inputs = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
+                    inputs = [
+                        transformer_outputs[input_id]
+                        for input_id in input_ids
+                        if input_id in transformer_outputs
+                    ]
 
                 # We execute the transformer when we have all data
                 if len(inputs) == len(input_ids):
@@ -74,16 +87,26 @@ class SequenceOrchestrator(AbstractOrchestrator):
                 transformer_manager = step["manager"]
                 input_ids = step["inputs"]
 
-                inputs = [input_data[input_id] for input_id in input_ids if input_id in input_data]
+                inputs = [
+                    input_data[input_id]
+                    for input_id in input_ids
+                    if input_id in input_data
+                ]
                 if len(inputs) > 0:
                     transformed_data = transformer_manager.transform(*inputs)
 
                     transformer_outputs[transformer_id] = transformed_data
                 else:
-                    transformers = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
-                    transformed_data = transformer_manager.transform(*transformers)
+                    transformers = [
+                        transformer_outputs[input_id]
+                        for input_id in input_ids
+                        if input_id in transformer_outputs
+                    ]
+                    transformed_data = transformer_manager.transform(
+                        *transformers
+                    )
                     transformer_outputs[transformer_id] = transformed_data
-                    
+
         self.elapsed_transform = self.benchmark.end("transform")
         self.logger.info("Finished transformers process.")
 
@@ -99,7 +122,11 @@ class SequenceOrchestrator(AbstractOrchestrator):
                 output_manager = step["manager"]
                 input_ids = step.get("inputs", [])
 
-                inputs = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
+                inputs = [
+                    transformer_outputs[input_id]
+                    for input_id in input_ids
+                    if input_id in transformer_outputs
+                ]
 
                 # Executing the output method
                 output_data = output_manager.put(*inputs)

--- a/cybertron_framework/orchestrator/types/sequence.py
+++ b/cybertron_framework/orchestrator/types/sequence.py
@@ -1,0 +1,117 @@
+import concurrent.futures
+from cybertron_framework.orchestrator.abstract_orchestrator import AbstractOrchestrator
+
+
+class SequenceOrchestrator(AbstractOrchestrator):
+    def run(self, pipeline_steps):
+        self.benchmark.start("total")
+
+        input_data = self._process_parallel_inputs(pipeline_steps)
+        
+        transformer_outputs = self._process_transformers(pipeline_steps, input_data)
+
+        self._process_output(pipeline_steps, transformer_outputs)
+
+        self.elapsed_total = self.benchmark.end("total")
+
+    def _process_parallel_inputs(self, pipeline_steps):
+        self.logger.info("Starting parallel input process.")
+        self.benchmark.start("input")
+
+        input_data = {}
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            input_futures = {
+                step["id"]: executor.submit(step["manager"].get_data)
+                for step in pipeline_steps
+                if step["type"] == "input"
+            }
+
+        for input_id, future in input_futures.items():
+            input_data[input_id] = future.result()
+
+        self.elapsed_input = self.benchmark.end("input")
+        self.logger.info("Finished parallel input process.")
+
+        return input_data
+    
+    def _process_transformers(self, pipeline_steps, input_data):
+        self.logger.info("Starting transformers process.")
+        self.benchmark.start("transform")
+
+        transformer_outputs = {}
+
+        for step in pipeline_steps:
+            if step["type"] == "transformer":
+                transformer_id = step["id"]
+                transformer_manager = step["manager"]
+                input_ids = step.get("inputs", [])
+
+                inputs = [input_data[input_id] for input_id in input_ids if input_id in input_data]
+
+                if not inputs:
+                    inputs = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
+
+                # We execute the transformer when we have all data
+                if len(inputs) == len(input_ids):
+                    transformed_data = transformer_manager.transform(*inputs)
+                    transformer_outputs[transformer_id] = transformed_data
+
+        self.elapsed_transform = self.benchmark.end("transform")
+        self.logger.info("Finished transformers process.")
+
+        return transformer_outputs
+
+    def _process_transformers_bak(self, pipeline_steps, input_data):
+        self.logger.info("Starting transformers process.")
+        self.benchmark.start("transform")
+
+        transformer_outputs = {}
+
+        for step in pipeline_steps:
+            if step["type"] == "transformer":
+                transformer_id = step["id"]
+                transformer_manager = step["manager"]
+                input_ids = step["inputs"]
+
+                inputs = [input_data[input_id] for input_id in input_ids if input_id in input_data]
+                if len(inputs) > 0:
+                    transformed_data = transformer_manager.transform(*inputs)
+
+                    transformer_outputs[transformer_id] = transformed_data
+                else:
+                    transformers = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
+                    transformed_data = transformer_manager.transform(*transformers)
+                    transformer_outputs[transformer_id] = transformed_data
+                    
+        self.elapsed_transform = self.benchmark.end("transform")
+        self.logger.info("Finished transformers process.")
+
+        return transformer_outputs
+
+    def _process_output(self, pipeline_steps, transformer_outputs):
+        self.logger.info("Starting output process.")
+        self.benchmark.start("output")
+
+        for step in pipeline_steps:
+            if step["type"] == "output":
+                output_id = step["id"]
+                output_manager = step["manager"]
+                input_ids = step.get("inputs", [])
+
+                inputs = [transformer_outputs[input_id] for input_id in input_ids if input_id in transformer_outputs]
+
+                # Executing the output method
+                output_data = output_manager.put(*inputs)
+                transformer_outputs[output_id] = output_data
+
+        self.elapsed_output = self.benchmark.end("output")
+        self.logger.info("Finished output process.")
+
+    def get_summary(self):
+        return {
+            "elapsed_total": self.elapsed_total,
+            "elapsed_input": self.elapsed_input,
+            "elapsed_transform": self.elapsed_transform,
+            "elapsed_output": self.elapsed_output,
+        }

--- a/cybertron_framework/orchestrator/types/sequence.py
+++ b/cybertron_framework/orchestrator/types/sequence.py
@@ -20,7 +20,7 @@ class SequenceOrchestrator(AbstractOrchestrator):
         self.elapsed_total = self.benchmark.end("total")
 
     def _process_parallel_inputs(self, pipeline_steps):
-        self.logger.info("Starting parallel input process.")
+        self.logger.info("Starting parallel input process (1/3).")
         self.benchmark.start("input")
 
         input_data = {}
@@ -41,7 +41,7 @@ class SequenceOrchestrator(AbstractOrchestrator):
         return input_data
 
     def _process_transformers(self, pipeline_steps, input_data):
-        self.logger.info("Starting transformers process.")
+        self.logger.info("Starting transformers process (2/3).")
         self.benchmark.start("transform")
 
         transformer_outputs = {}
@@ -75,45 +75,8 @@ class SequenceOrchestrator(AbstractOrchestrator):
 
         return transformer_outputs
 
-    def _process_transformers_bak(self, pipeline_steps, input_data):
-        self.logger.info("Starting transformers process.")
-        self.benchmark.start("transform")
-
-        transformer_outputs = {}
-
-        for step in pipeline_steps:
-            if step["type"] == "transformer":
-                transformer_id = step["id"]
-                transformer_manager = step["manager"]
-                input_ids = step["inputs"]
-
-                inputs = [
-                    input_data[input_id]
-                    for input_id in input_ids
-                    if input_id in input_data
-                ]
-                if len(inputs) > 0:
-                    transformed_data = transformer_manager.transform(*inputs)
-
-                    transformer_outputs[transformer_id] = transformed_data
-                else:
-                    transformers = [
-                        transformer_outputs[input_id]
-                        for input_id in input_ids
-                        if input_id in transformer_outputs
-                    ]
-                    transformed_data = transformer_manager.transform(
-                        *transformers
-                    )
-                    transformer_outputs[transformer_id] = transformed_data
-
-        self.elapsed_transform = self.benchmark.end("transform")
-        self.logger.info("Finished transformers process.")
-
-        return transformer_outputs
-
     def _process_output(self, pipeline_steps, transformer_outputs):
-        self.logger.info("Starting output process.")
+        self.logger.info("Starting output process (3/3).")
         self.benchmark.start("output")
 
         for step in pipeline_steps:

--- a/cybertron_framework/orchestrator/types/synchronous.py
+++ b/cybertron_framework/orchestrator/types/synchronous.py
@@ -62,10 +62,10 @@ class Orchestrator(AbstractOrchestrator):
                 transformer_manager_id
             ]
 
-            transformed_data[transformer_manager.get_id()] = (
-                transformer_manager.transform(
-                    input_data[transformer_manager_id]
-                )
+            transformed_data[
+                transformer_manager.get_id()
+            ] = transformer_manager.transform(
+                input_data[transformer_manager_id]
             )
 
         self.elapsed_transform = self.benchmark.end("transform")

--- a/cybertron_framework/output/output_manager_interface.py
+++ b/cybertron_framework/output/output_manager_interface.py
@@ -12,7 +12,7 @@ class IOutputManager:
         raise NotImplementedError
 
     @abstractmethod
-    def put(self, data):
+    def put(self, *data):
         """
         Puts the transformed data
         """

--- a/cybertron_framework/transformer/transformer_manager_interface.py
+++ b/cybertron_framework/transformer/transformer_manager_interface.py
@@ -12,7 +12,7 @@ class ITransformerManager:
         raise NotImplementedError
 
     @abstractmethod
-    def transform(self, data):
+    def transform(self, *args):
         """
         Transforms the input data
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,3 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 79
-


### PR DESCRIPTION
We created a new orchestrator where it allows us to define the order of execution of each step.
Now we can have Transformers where the input is the output of another Transformer.

```python
from cybertron_framework.orchestrator.types.sequence import SequenceOrchestrator

pipeline_steps = [
    {"id": "input1", "type": "input", "manager": EmployeeInputBigqueryManager()},
    {"id": "input2", "type": "input", "manager": EmployeeInputPostgresManager()},
    {"id": "transformer1", "type": "transformer", "manager": EmployeeTransformerBigqueryManager(), "inputs": ["input1"]},
    {"id": "transformer2", "type": "transformer", "manager": EmployeeTransformerPostgresManager(), "inputs": ["input2"]},
    {"id": "transformer3", "type": "transformer", "manager": FinalTransformerManager(), "inputs": ["transformer1", "transformer2"]},
    {"id": "output1", "type": "output", "manager": FirstOutputManager(), "inputs": ["transformer3"]},
]

orchestrator = SequenceOrchestrator()
orchestrator.run(pipeline_steps)
```